### PR TITLE
fixed locale_file_service.dart

### DIFF
--- a/lib/src/services/locale_file_service.dart
+++ b/lib/src/services/locale_file_service.dart
@@ -44,13 +44,6 @@ class LocaleFileService
     {
         var file = _getFilepath(languageCode, basePath);
 
-        if(!localizedFiles.contains(file))
-        {
-            if(languageCode.contains('_'))
-            {
-                file = _getFilepath(languageCode.split('_').first, basePath);
-            }
-        }
 
         if(file == null)
         {


### PR DESCRIPTION
the original _findLocaleFile method contains a needless if statement that is not reflective of the rest of the library and breaks whenever a file has _ in its name (en_US defaults to en)

this is not how the same thing is handled in utils.localeFromString which is correct